### PR TITLE
node bump to v20 due to fetch incompatibility

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -17,7 +17,7 @@ jobs:
     env:
       user: ${{ vars.USER }}
     steps: 
-      - uses: actions/setup-node@55832442197ac5d11caf9c5b0208c1d23d3a6c2d
+      - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d
         with:
           node-version: '18' 
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -17,6 +17,9 @@ jobs:
     env:
       user: ${{ vars.USER }}
     steps: 
+      - uses: actions/setup-node@55832442197ac5d11caf9c5b0208c1d23d3a6c2d
+        with:
+          node-version: '18' 
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       # make sure we have a new build, in case the dist folder was not updated
       - name: Compile with NPM

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -17,9 +17,6 @@ jobs:
     env:
       user: ${{ vars.USER }}
     steps: 
-      - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d
-        with:
-          node-version: '18' 
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       # make sure we have a new build, in case the dist folder was not updated
       - name: Compile with NPM

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,7 +17,11 @@ jobs:
       cancel-in-progress: false
     env:
       user: ${{ vars.USER }}
-    steps: 
+      
+    steps:
+      - uses: actions/setup-node@55832442197ac5d11caf9c5b0208c1d23d3a6c2d
+        with:
+          node-version: '18' 
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       # make sure we have a new build, in case the dist folder was not updated
       - name: Compile with NPM

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,7 +19,7 @@ jobs:
       user: ${{ vars.USER }}
       
     steps:
-      - uses: actions/setup-node@55832442197ac5d11caf9c5b0208c1d23d3a6c2d
+      - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d
         with:
           node-version: '18' 
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,9 +19,6 @@ jobs:
       user: ${{ vars.USER }}
       
     steps:
-      - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d
-        with:
-          node-version: '18' 
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       # make sure we have a new build, in case the dist folder was not updated
       - name: Compile with NPM

--- a/action.yml
+++ b/action.yml
@@ -36,5 +36,5 @@ outputs:
   actions-file-path:
     description: 'Path to the file that contains a list of all actions available in the organization or user space'  
 runs:
-  using: 'node18'
+  using: 'node20'
   main: 'dist/main.js'

--- a/action.yml
+++ b/action.yml
@@ -36,5 +36,5 @@ outputs:
   actions-file-path:
     description: 'Path to the file that contains a list of all actions available in the organization or user space'  
 runs:
-  using: 'node16'
+  using: 'node18'
   main: 'dist/main.js'

--- a/dist/main.js
+++ b/dist/main.js
@@ -5512,12 +5512,12 @@ var require_lib3 = __commonJS({
       const dest = new URL$1(destination).protocol;
       return orig === dest;
     };
-    function fetch(url, opts) {
-      if (!fetch.Promise) {
+    function fetch2(url, opts) {
+      if (!fetch2.Promise) {
         throw new Error("native promise missing, set fetch.Promise to your favorite alternative");
       }
-      Body.Promise = fetch.Promise;
-      return new fetch.Promise(function(resolve, reject) {
+      Body.Promise = fetch2.Promise;
+      return new fetch2.Promise(function(resolve, reject) {
         const request = new Request(url, opts);
         const options = getNodeRequestOptions(request);
         const send = (options.protocol === "https:" ? https : http).request;
@@ -5590,7 +5590,7 @@ var require_lib3 = __commonJS({
         req.on("response", function(res) {
           clearTimeout(reqTimeout);
           const headers = createHeadersLenient(res.headers);
-          if (fetch.isRedirect(res.statusCode)) {
+          if (fetch2.isRedirect(res.statusCode)) {
             const location = headers.get("Location");
             let locationURL = null;
             try {
@@ -5652,7 +5652,7 @@ var require_lib3 = __commonJS({
                   requestOpts.body = void 0;
                   requestOpts.headers.delete("content-length");
                 }
-                resolve(fetch(new Request(locationURL, requestOpts)));
+                resolve(fetch2(new Request(locationURL, requestOpts)));
                 finalize();
                 return;
             }
@@ -5745,11 +5745,11 @@ var require_lib3 = __commonJS({
         stream.end();
       }
     }
-    fetch.isRedirect = function(code) {
+    fetch2.isRedirect = function(code) {
       return code === 301 || code === 302 || code === 303 || code === 307 || code === 308;
     };
-    fetch.Promise = global.Promise;
-    module2.exports = exports = fetch;
+    fetch2.Promise = global.Promise;
+    module2.exports = exports = fetch2;
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.default = exports;
     exports.Headers = Headers;
@@ -5961,9 +5961,9 @@ var require_dist_node5 = __commonJS({
       let headers = {};
       let status;
       let url;
-      const fetch = requestOptions.request && requestOptions.request.fetch || globalThis.fetch || /* istanbul ignore next */
+      const fetch2 = requestOptions.request && requestOptions.request.fetch || globalThis.fetch || /* istanbul ignore next */
       import_node_fetch.default;
-      return fetch(
+      return fetch2(
         requestOptions.url,
         Object.assign(
           {
@@ -31280,7 +31280,10 @@ async function run() {
     }
     const octokit = new import_octokit.Octokit({
       auth: PAT,
-      baseUrl
+      baseUrl,
+      request: {
+        fetch
+      }
     });
     try {
     } catch (error2) {
@@ -31764,7 +31767,7 @@ async function getActionInfo(client, owner, repo, path2, forkedFrom, isArchived 
   const result = new ActionContent();
   if ("name" in yaml && "download_url" in yaml) {
     result.name = (0, import_html_entities2.encode)(yaml.name, { mode: "extensive" });
-    result.repo = (0, import_html_entities2.encode)(repo, { mode: "extensive" });
+    result.repo = repo;
     result.forkedfrom = (0, import_html_entities2.encode)(forkedFrom, { mode: "extensive" });
     result.isArchived = isArchived;
     if (yaml.download_url !== null) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,10 +53,7 @@ async function run(): Promise<void> {
 
     const octokit = new Octokit({
       auth: PAT,
-      baseUrl,
-      request: {
-        fetch
-      }
+      baseUrl
     })
 
     try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,6 @@ import dotenv from 'dotenv'
 import fs from 'fs'
 import path from 'path'
 import {getReadmeContent} from './optionalActions'
-
 import {execSync} from 'child_process'
 import {Buffer} from 'buffer'
 import {encode} from 'html-entities'
@@ -54,7 +53,10 @@ async function run(): Promise<void> {
 
     const octokit = new Octokit({
       auth: PAT,
-      baseUrl
+      baseUrl,
+      request: {
+        fetch
+      }
     })
 
     try {


### PR DESCRIPTION
Octokit [is now unsupported on node 16 for a native fetch API](https://github.com/octokit/octokit.js/#fetch-missing). Instead of backporting fetch built on newer engine this PR updates node to v20. 
Successful run on v20: https://github.com/asml-actions/load-available-actions/actions/runs/6379934500/job/17313375384
